### PR TITLE
Add a more comprehensive JSON file to track versions

### DIFF
--- a/product-versions.json
+++ b/product-versions.json
@@ -8,7 +8,7 @@
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
           "version": "1.3.0",
-          "types" : [
+          "componentTypes" : [
             {
               "name": "dockerImage",
               "platforms": [
@@ -21,15 +21,56 @@
                   ]
                 }
               ]
+            },
+            {
+              "name": "package",
+              "platforms": [
+                {
+                  // https://packages.microsoft.com/debian/11/prod/pool/main/
+                  "os": "debian",
+                  "version": "11",
+                  "arch": [
+                    "armhf"
+                  ]
+                },
+                {
+                  // https://packages.microsoft.com/rhel/8/prod/
+                  "os": "redhat",
+                  "version": "8",
+                  "arch": [
+                    "x86_64"
+                  ]
+                },
+                {
+                  // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/
+                  "os": "ubuntu",
+                  "version": "18.04",
+                  "arch": [
+                    "amd64",
+                    "arm64"
+                  ]
+                },
+                {
+                  // https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/
+                  "os": "ubuntu",
+                  "version": "20.04",
+                  "arch": [
+                    "amd64",
+                    "arm64"
+                  ]
+                }
+              ]
             }
           ],
           "components": [
             {
               "name": "aziot-edge",
+              "type": "package",
               "version": "1.3.0"
             },
             {
               "name": "aziot-identity-service",
+              "type": "package",
               "version": "1.3.0"
             },
             {
@@ -57,7 +98,7 @@
         {
           "name": "Metrics Collector",
           "id": "metrics-collector",
-          "types" : [
+          "componentTypes" : [
             {
               "name": "dockerImage",
               "platforms": [
@@ -83,7 +124,7 @@
         {
           "name": "API Proxy",
           "id": "metrics-collector",
-          "types" : [
+          "componentTypes" : [
             {
               "name": "dockerImage",
               "platforms": [
@@ -115,7 +156,7 @@
           "name": "Azure IoT Edge 1.1 LTS",
           "id": "aziot-edge",
           "version": "1.1.15",
-          "types" : [
+          "componentTypes" : [
             {
               "name": "dockerImage",
               "platforms": [
@@ -134,11 +175,49 @@
                   ]
                 }
               ]
+            },
+            {
+              // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/i/iotedge/
+              "name": "package",
+              "platforms": [
+                {
+                  // https://packages.microsoft.com/debian/stretch/multiarch/prod/pool/main/i/iotedge/
+                  "os": "debian",
+                  "version": "stretch",
+                  "arch": [
+                    "armhf"
+                  ]
+                },
+                {
+                  // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/
+                  "os": "ubuntu",
+                  "version": "18.04",
+                  "arch": [
+                    "amd64",
+                    "arm64"
+                  ]
+                },
+                {
+                  // https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/
+                  "os": "ubuntu",
+                  "version": "20.04",
+                  "arch": [
+                    "amd64",
+                    "arm64"
+                  ]
+                }
+              ]
             }
           ],
           "components": [
             {
               "name": "iotedge",
+              "type": "package",
+              "version": "1.1.15"
+            },
+            {
+              "name": "libiothsm-std",
+              "type": "package",
               "version": "1.1.15"
             },
             {

--- a/product-versions.json
+++ b/product-versions.json
@@ -219,5 +219,44 @@
         }
       ]
     }
+  ],
+  "sources": [
+    {
+      "repo": "Azure/iotedge",
+      "branch": "release/1.4",
+      "products": [
+        {
+          "channel": "stable",
+          "id": "aziot-edge",
+          "version": "1.4"
+        },
+        {
+          "channel": "stable",
+          "id": "api-proxy",
+          "version": "1"
+        },
+        {
+          "channel": "lts",
+          "id": "aziot-edge",
+          "version": "1.4"
+        }
+      ]
+    },
+    {
+      "repo": "Azure/iotedge",
+      "branch": "release/1.1",
+      "products": [
+        {
+          "channel": "stable",
+          "id": "metrics-collector",
+          "version": "1"
+        },
+        {
+          "channel": "lts",
+          "id": "aziot-edge",
+          "version": "1.1"
+        }
+      ]
+    }
   ]
 }

--- a/product-versions.json
+++ b/product-versions.json
@@ -7,7 +7,7 @@
         {
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
-          "version": "1.4.0",
+          "version": "1.4.1",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -26,11 +26,11 @@
           "components": [
             {
               "name": "aziot-edge",
-              "version": "1.4.0"
+              "version": "1.4.1"
             },
             {
               "name": "aziot-identity-service",
-              "version": "1.4.0"
+              "version": "1.4.1"
             },
             {
               "name": "azureiotedge-agent",
@@ -50,14 +50,14 @@
             {
               "name": "azureiotedge-diagnostics",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.1"
             }
           ]
         },
         {
           "name": "Metrics Collector",
           "id": "metrics-collector",
-          "version": "1.0.9",
+          "version": "1.0.10",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -77,7 +77,7 @@
             {
               "name": "azureiotedge-metrics-collector",
               "type": "dockerImage",
-              "version": "1.0.9"
+              "version": "1.0.10"
             }
           ]
         },
@@ -116,7 +116,7 @@
         {
           "name": "Azure IoT Edge 1.4 LTS",
           "id": "aziot-edge",
-          "version": "1.4.0",
+          "version": "1.4.1",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -135,11 +135,11 @@
           "components": [
             {
               "name": "aziot-edge",
-              "version": "1.4.0"
+              "version": "1.4.1"
             },
             {
               "name": "aziot-identity-service",
-              "version": "1.4.0"
+              "version": "1.4.1"
             },
             {
               "name": "azureiotedge-agent",
@@ -159,7 +159,7 @@
             {
               "name": "azureiotedge-diagnostics",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.1"
             }
           ]
         },

--- a/product-versions.json
+++ b/product-versions.json
@@ -35,20 +35,28 @@
             {
               "name": "azureiotedge-agent",
               "type": "dockerImage",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-hub",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-diagnostics",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.1"
             }
@@ -76,6 +84,8 @@
           "components": [
             {
               "name": "azureiotedge-metrics-collector",
+              "branch": "release/1.1",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.0.10"
             }
@@ -103,6 +113,8 @@
           "components": [
             {
               "name": "azureiotedge-api-proxy",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.1.3"
             }
@@ -143,21 +155,29 @@
             },
             {
               "name": "azureiotedge-agent",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-hub",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.0"
             },
             {
               "name": "azureiotedge-diagnostics",
+              "branch": "release/1.4",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.4.1"
             }
@@ -199,64 +219,33 @@
             },
             {
               "name": "azureiotedge-agent",
+              "branch": "release/1.1",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.1.16"
             },
             {
               "name": "azureiotedge-hub",
+              "branch": "release/1.1",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.1.16"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
+              "branch": "release/1.1",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.1.16"
             },
             {
               "name": "azureiotedge-diagnostics",
+              "branch": "release/1.1",
+              "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.1.16"
             }
           ]
-        }
-      ]
-    }
-  ],
-  "sources": [
-    {
-      "repo": "Azure/iotedge",
-      "branch": "release/1.4",
-      "products": [
-        {
-          "channel": "stable",
-          "id": "aziot-edge",
-          "version": "1.4"
-        },
-        {
-          "channel": "stable",
-          "id": "api-proxy",
-          "version": "1"
-        },
-        {
-          "channel": "lts",
-          "id": "aziot-edge",
-          "version": "1.4"
-        }
-      ]
-    },
-    {
-      "repo": "Azure/iotedge",
-      "branch": "release/1.1",
-      "products": [
-        {
-          "channel": "stable",
-          "id": "metrics-collector",
-          "version": "1"
-        },
-        {
-          "channel": "lts",
-          "id": "aziot-edge",
-          "version": "1.1"
         }
       ]
     }

--- a/product-versions.json
+++ b/product-versions.json
@@ -26,7 +26,6 @@
               "name": "package",
               "platforms": [
                 {
-                  // https://packages.microsoft.com/debian/11/prod/pool/main/
                   "os": "debian",
                   "version": "11",
                   "arch": [
@@ -34,7 +33,6 @@
                   ]
                 },
                 {
-                  // https://packages.microsoft.com/rhel/8/prod/
                   "os": "redhat",
                   "version": "8",
                   "arch": [
@@ -42,7 +40,6 @@
                   ]
                 },
                 {
-                  // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/
                   "os": "ubuntu",
                   "version": "18.04",
                   "arch": [
@@ -51,7 +48,6 @@
                   ]
                 },
                 {
-                  // https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/
                   "os": "ubuntu",
                   "version": "20.04",
                   "arch": [
@@ -177,11 +173,9 @@
               ]
             },
             {
-              // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/i/iotedge/
               "name": "package",
               "platforms": [
                 {
-                  // https://packages.microsoft.com/debian/stretch/multiarch/prod/pool/main/i/iotedge/
                   "os": "debian",
                   "version": "stretch",
                   "arch": [
@@ -189,7 +183,6 @@
                   ]
                 },
                 {
-                  // https://packages.microsoft.com/ubuntu/18.04/multiarch/prod/pool/main/
                   "os": "ubuntu",
                   "version": "18.04",
                   "arch": [
@@ -198,7 +191,6 @@
                   ]
                 },
                 {
-                  // https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/
                   "os": "ubuntu",
                   "version": "20.04",
                   "arch": [

--- a/product-versions.json
+++ b/product-versions.json
@@ -7,7 +7,7 @@
         {
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
-          "version": "1.4.1",
+          "version": "1.4.2",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -26,7 +26,7 @@
           "components": [
             {
               "name": "aziot-edge",
-              "version": "1.4.1"
+              "version": "1.4.2"
             },
             {
               "name": "aziot-identity-service",
@@ -37,28 +37,28 @@
               "type": "dockerImage",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-hub",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-diagnostics",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.1"
+              "version": "1.4.2"
             }
           ]
         },
@@ -128,7 +128,7 @@
         {
           "name": "Azure IoT Edge 1.4 LTS",
           "id": "aziot-edge",
-          "version": "1.4.1",
+          "version": "1.4.2",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -147,7 +147,7 @@
           "components": [
             {
               "name": "aziot-edge",
-              "version": "1.4.1"
+              "version": "1.4.2"
             },
             {
               "name": "aziot-identity-service",
@@ -158,28 +158,28 @@
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-hub",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.0"
+              "version": "1.4.2"
             },
             {
               "name": "azureiotedge-diagnostics",
               "branch": "release/1.4",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.4.1"
+              "version": "1.4.2"
             }
           ]
         },

--- a/product-versions.json
+++ b/product-versions.json
@@ -8,6 +8,21 @@
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
           "version": "1.3.0",
+          "types" : [
+            {
+              "name": "dockerImage",
+              "platforms": [
+                {
+                  "os": "linux",
+                  "arch": [
+                    "amd64",
+                    "arm64v8",
+                    "arm32v7"
+                  ]
+                }
+              ]
+            }
+          ],
           "components": [
             {
               "name": "aziot-edge",
@@ -42,6 +57,21 @@
         {
           "name": "Metrics Collector",
           "id": "metrics-collector",
+          "types" : [
+            {
+              "name": "dockerImage",
+              "platforms": [
+                {
+                  "os": "linux",
+                  "arch": [
+                    "amd64",
+                    "arm64v8",
+                    "arm32v7"
+                  ]
+                }
+              ]
+            }
+          ],
           "components": [
             {
               "name": "azureiotedge-metrics-collector",
@@ -53,6 +83,21 @@
         {
           "name": "API Proxy",
           "id": "metrics-collector",
+          "types" : [
+            {
+              "name": "dockerImage",
+              "platforms": [
+                {
+                  "os": "linux",
+                  "arch": [
+                    "amd64",
+                    "arm64v8",
+                    "arm32v7"
+                  ]
+                }
+              ]
+            }
+          ],
           "components": [
             {
               "name": "azureiotedge-api-proxy",
@@ -70,6 +115,27 @@
           "name": "Azure IoT Edge 1.1 LTS",
           "id": "aziot-edge",
           "version": "1.1.15",
+          "types" : [
+            {
+              "name": "dockerImage",
+              "platforms": [
+                {
+                  "os": "linux",
+                  "arch": [
+                    "amd64",
+                    "arm64v8",
+                    "arm32v7"
+                  ]
+                },
+                {
+                  "os": "windows",
+                  "arch": [
+                    "amd64"
+                  ]
+                }
+              ]
+            }
+          ],
           "components": [
             {
               "name": "iotedge",

--- a/product-versions.json
+++ b/product-versions.json
@@ -82,7 +82,7 @@
         },
         {
           "name": "API Proxy",
-          "id": "metrics-collector",
+          "id": "api-proxy",
           "componentTypes" : [
             {
               "name": "dockerImage",

--- a/product-versions.json
+++ b/product-versions.json
@@ -1,0 +1,104 @@
+{
+    "schemaVersion": "1.0",
+    "channels": [
+      {
+        "name": "stable",
+        "products":   [
+          {
+            "name": "Azure IoT Edge",
+            "id": "aziot-edge",
+            "version": "1.3.0",
+            "components": [
+              {
+                "name": "aziot-edge",
+                "version": "1.3.0"
+              },
+              {
+                "name": "aziot-identity-service",
+                "version": "1.3.0"
+              },
+                {
+                "name": "azureiotedge-agent",
+                "type": "dockerImage",
+                "version": "1.3.0"
+              },
+              {
+                "name": "azureiotedge-hub",
+                "type": "dockerImage",
+                "version": "1.3.0"
+              },
+              {
+                "name": "azureiotedge-simulated-temperature-sensor",
+                "type": "dockerImage",
+                "version": "1.3.0"
+              },
+              {
+                "name": "azureiotedge-diagnostics",
+                "type": "dockerImage",
+                "version": "1.3.0"
+              }
+            ]
+          },
+          {
+            "name": "Metrics Collector",
+            "id": "metrics-collector",
+            "components": [
+              {
+                "name": "azureiotedge-metrics-collector",
+                "type": "dockerImage",
+                "version": "1.0.9"
+              }
+            ]
+          },
+          {
+            "name": "API Proxy",
+            "id": "metrics-collector",
+            "components": [
+              {
+                "name": "azureiotedge-api-proxy",
+                "type": "dockerImage",
+                "version": "1.1.3"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "lts",
+        "products": [
+          {
+            "name": "Azure IoT Edge 1.1 LTS",
+            "id": "aziot-edge",
+            "version": "1.1.15",
+            "components": [
+              {
+                "name": "iotedge",
+                "version": "1.1.15"
+              },
+              {
+                "name": "azureiotedge-agent",
+                "type": "dockerImage",
+                "version": "1.1.15"
+              },
+              {
+                "name": "azureiotedge-hub",
+                "type": "dockerImage",
+                "version": "1.1.15"
+              },
+              {
+                "name": "azureiotedge-simulated-temperature-sensor",
+                "type": "dockerImage",
+                "version": "1.1.15"
+              },
+              {
+                "name": "azureiotedge-diagnostics",
+                "type": "dockerImage",
+                "version": "1.1.15"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/product-versions.json
+++ b/product-versions.json
@@ -8,7 +8,7 @@
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
           "version": "1.4.0",
-          "componentTypes" : [
+          "componentTypes": [
             {
               "name": "dockerImage",
               "platforms": [
@@ -57,7 +57,8 @@
         {
           "name": "Metrics Collector",
           "id": "metrics-collector",
-          "componentTypes" : [
+          "version": "1.0.9",
+          "componentTypes": [
             {
               "name": "dockerImage",
               "platforms": [
@@ -83,7 +84,8 @@
         {
           "name": "API Proxy",
           "id": "api-proxy",
-          "componentTypes" : [
+          "version": "1.1.3",
+          "componentTypes": [
             {
               "name": "dockerImage",
               "platforms": [
@@ -115,7 +117,7 @@
           "name": "Azure IoT Edge 1.4 LTS",
           "id": "aziot-edge",
           "version": "1.4.0",
-          "componentTypes" : [
+          "componentTypes": [
             {
               "name": "dockerImage",
               "platforms": [
@@ -165,7 +167,7 @@
           "name": "Azure IoT Edge 1.1 LTS",
           "id": "aziot-edge",
           "version": "1.1.16",
-          "componentTypes" : [
+          "componentTypes": [
             {
               "name": "dockerImage",
               "platforms": [

--- a/product-versions.json
+++ b/product-versions.json
@@ -1,104 +1,103 @@
 {
-    "schemaVersion": "1.0",
-    "channels": [
-      {
-        "name": "stable",
-        "products":   [
-          {
-            "name": "Azure IoT Edge",
-            "id": "aziot-edge",
-            "version": "1.3.0",
-            "components": [
-              {
-                "name": "aziot-edge",
-                "version": "1.3.0"
-              },
-              {
-                "name": "aziot-identity-service",
-                "version": "1.3.0"
-              },
-                {
-                "name": "azureiotedge-agent",
-                "type": "dockerImage",
-                "version": "1.3.0"
-              },
-              {
-                "name": "azureiotedge-hub",
-                "type": "dockerImage",
-                "version": "1.3.0"
-              },
-              {
-                "name": "azureiotedge-simulated-temperature-sensor",
-                "type": "dockerImage",
-                "version": "1.3.0"
-              },
-              {
-                "name": "azureiotedge-diagnostics",
-                "type": "dockerImage",
-                "version": "1.3.0"
-              }
-            ]
-          },
-          {
-            "name": "Metrics Collector",
-            "id": "metrics-collector",
-            "components": [
-              {
-                "name": "azureiotedge-metrics-collector",
-                "type": "dockerImage",
-                "version": "1.0.9"
-              }
-            ]
-          },
-          {
-            "name": "API Proxy",
-            "id": "metrics-collector",
-            "components": [
-              {
-                "name": "azureiotedge-api-proxy",
-                "type": "dockerImage",
-                "version": "1.1.3"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "lts",
-        "products": [
-          {
-            "name": "Azure IoT Edge 1.1 LTS",
-            "id": "aziot-edge",
-            "version": "1.1.15",
-            "components": [
-              {
-                "name": "iotedge",
-                "version": "1.1.15"
-              },
-              {
-                "name": "azureiotedge-agent",
-                "type": "dockerImage",
-                "version": "1.1.15"
-              },
-              {
-                "name": "azureiotedge-hub",
-                "type": "dockerImage",
-                "version": "1.1.15"
-              },
-              {
-                "name": "azureiotedge-simulated-temperature-sensor",
-                "type": "dockerImage",
-                "version": "1.1.15"
-              },
-              {
-                "name": "azureiotedge-diagnostics",
-                "type": "dockerImage",
-                "version": "1.1.15"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+  "schemaVersion": "1.0",
+  "channels": [
+    {
+      "name": "stable",
+      "products": [
+        {
+          "name": "Azure IoT Edge",
+          "id": "aziot-edge",
+          "version": "1.3.0",
+          "components": [
+            {
+              "name": "aziot-edge",
+              "version": "1.3.0"
+            },
+            {
+              "name": "aziot-identity-service",
+              "version": "1.3.0"
+            },
+            {
+              "name": "azureiotedge-agent",
+              "type": "dockerImage",
+              "version": "1.3.0"
+            },
+            {
+              "name": "azureiotedge-hub",
+              "type": "dockerImage",
+              "version": "1.3.0"
+            },
+            {
+              "name": "azureiotedge-simulated-temperature-sensor",
+              "type": "dockerImage",
+              "version": "1.3.0"
+            },
+            {
+              "name": "azureiotedge-diagnostics",
+              "type": "dockerImage",
+              "version": "1.3.0"
+            }
+          ]
+        },
+        {
+          "name": "Metrics Collector",
+          "id": "metrics-collector",
+          "components": [
+            {
+              "name": "azureiotedge-metrics-collector",
+              "type": "dockerImage",
+              "version": "1.0.9"
+            }
+          ]
+        },
+        {
+          "name": "API Proxy",
+          "id": "metrics-collector",
+          "components": [
+            {
+              "name": "azureiotedge-api-proxy",
+              "type": "dockerImage",
+              "version": "1.1.3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "lts",
+      "products": [
+        {
+          "name": "Azure IoT Edge 1.1 LTS",
+          "id": "aziot-edge",
+          "version": "1.1.15",
+          "components": [
+            {
+              "name": "iotedge",
+              "version": "1.1.15"
+            },
+            {
+              "name": "azureiotedge-agent",
+              "type": "dockerImage",
+              "version": "1.1.15"
+            },
+            {
+              "name": "azureiotedge-hub",
+              "type": "dockerImage",
+              "version": "1.1.15"
+            },
+            {
+              "name": "azureiotedge-simulated-temperature-sensor",
+              "type": "dockerImage",
+              "version": "1.1.15"
+            },
+            {
+              "name": "azureiotedge-diagnostics",
+              "type": "dockerImage",
+              "version": "1.1.15"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/product-versions.json
+++ b/product-versions.json
@@ -7,7 +7,7 @@
         {
           "name": "Azure IoT Edge",
           "id": "aziot-edge",
-          "version": "1.3.0",
+          "version": "1.4.0",
           "componentTypes" : [
             {
               "name": "dockerImage",
@@ -26,31 +26,31 @@
           "components": [
             {
               "name": "aziot-edge",
-              "version": "1.3.0"
+              "version": "1.4.0"
             },
             {
               "name": "aziot-identity-service",
-              "version": "1.3.0"
+              "version": "1.4.0"
             },
             {
               "name": "azureiotedge-agent",
               "type": "dockerImage",
-              "version": "1.3.0"
+              "version": "1.4.0"
             },
             {
               "name": "azureiotedge-hub",
               "type": "dockerImage",
-              "version": "1.3.0"
+              "version": "1.4.0"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
               "type": "dockerImage",
-              "version": "1.3.0"
+              "version": "1.4.0"
             },
             {
               "name": "azureiotedge-diagnostics",
               "type": "dockerImage",
-              "version": "1.3.0"
+              "version": "1.4.0"
             }
           ]
         },
@@ -112,9 +112,59 @@
       "name": "lts",
       "products": [
         {
+          "name": "Azure IoT Edge 1.4 LTS",
+          "id": "aziot-edge",
+          "version": "1.4.0",
+          "componentTypes" : [
+            {
+              "name": "dockerImage",
+              "platforms": [
+                {
+                  "os": "linux",
+                  "arch": [
+                    "amd64",
+                    "arm64v8",
+                    "arm32v7"
+                  ]
+                }
+              ]
+            }
+          ],
+          "components": [
+            {
+              "name": "aziot-edge",
+              "version": "1.4.0"
+            },
+            {
+              "name": "aziot-identity-service",
+              "version": "1.4.0"
+            },
+            {
+              "name": "azureiotedge-agent",
+              "type": "dockerImage",
+              "version": "1.4.0"
+            },
+            {
+              "name": "azureiotedge-hub",
+              "type": "dockerImage",
+              "version": "1.4.0"
+            },
+            {
+              "name": "azureiotedge-simulated-temperature-sensor",
+              "type": "dockerImage",
+              "version": "1.4.0"
+            },
+            {
+              "name": "azureiotedge-diagnostics",
+              "type": "dockerImage",
+              "version": "1.4.0"
+            }
+          ]
+        },
+        {
           "name": "Azure IoT Edge 1.1 LTS",
           "id": "aziot-edge",
-          "version": "1.1.15",
+          "version": "1.1.16",
           "componentTypes" : [
             {
               "name": "dockerImage",
@@ -148,22 +198,22 @@
             {
               "name": "azureiotedge-agent",
               "type": "dockerImage",
-              "version": "1.1.15"
+              "version": "1.1.16"
             },
             {
               "name": "azureiotedge-hub",
               "type": "dockerImage",
-              "version": "1.1.15"
+              "version": "1.1.16"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
               "type": "dockerImage",
-              "version": "1.1.15"
+              "version": "1.1.16"
             },
             {
               "name": "azureiotedge-diagnostics",
               "type": "dockerImage",
-              "version": "1.1.15"
+              "version": "1.1.16"
             }
           ]
         }

--- a/product-versions.json
+++ b/product-versions.json
@@ -21,52 +21,15 @@
                   ]
                 }
               ]
-            },
-            {
-              "name": "package",
-              "platforms": [
-                {
-                  "os": "debian",
-                  "version": "11",
-                  "arch": [
-                    "armhf"
-                  ]
-                },
-                {
-                  "os": "redhat",
-                  "version": "8",
-                  "arch": [
-                    "x86_64"
-                  ]
-                },
-                {
-                  "os": "ubuntu",
-                  "version": "18.04",
-                  "arch": [
-                    "amd64",
-                    "arm64"
-                  ]
-                },
-                {
-                  "os": "ubuntu",
-                  "version": "20.04",
-                  "arch": [
-                    "amd64",
-                    "arm64"
-                  ]
-                }
-              ]
             }
           ],
           "components": [
             {
               "name": "aziot-edge",
-              "type": "package",
               "version": "1.3.0"
             },
             {
               "name": "aziot-identity-service",
-              "type": "package",
               "version": "1.3.0"
             },
             {
@@ -171,45 +134,15 @@
                   ]
                 }
               ]
-            },
-            {
-              "name": "package",
-              "platforms": [
-                {
-                  "os": "debian",
-                  "version": "stretch",
-                  "arch": [
-                    "armhf"
-                  ]
-                },
-                {
-                  "os": "ubuntu",
-                  "version": "18.04",
-                  "arch": [
-                    "amd64",
-                    "arm64"
-                  ]
-                },
-                {
-                  "os": "ubuntu",
-                  "version": "20.04",
-                  "arch": [
-                    "amd64",
-                    "arm64"
-                  ]
-                }
-              ]
             }
           ],
           "components": [
             {
               "name": "iotedge",
-              "type": "package",
               "version": "1.1.15"
             },
             {
               "name": "libiothsm-std",
-              "type": "package",
               "version": "1.1.15"
             },
             {

--- a/product-versions.json
+++ b/product-versions.json
@@ -186,7 +186,7 @@
         {
           "name": "Azure IoT Edge 1.1 LTS",
           "id": "aziot-edge",
-          "version": "1.1.16",
+          "version": "1.1.17",
           "componentTypes": [
             {
               "name": "dockerImage",
@@ -222,28 +222,28 @@
               "branch": "release/1.1",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.1.16"
+              "version": "1.1.17"
             },
             {
               "name": "azureiotedge-hub",
               "branch": "release/1.1",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.1.16"
+              "version": "1.1.17"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
               "branch": "release/1.1",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.1.16"
+              "version": "1.1.17"
             },
             {
               "name": "azureiotedge-diagnostics",
               "branch": "release/1.1",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
-              "version": "1.1.16"
+              "version": "1.1.17"
             }
           ]
         }


### PR DESCRIPTION
A fully automated image publishing pipeline needs to access a file that tells it exactly which products and components to update, and to what version. In contrast, our current pipeline requires that someone supply the version as a parameter when they run the pipeline. Not only is this error prone, but it is inflexible--we have a single version parameter that applies to all images.

We have some existing files that are obvious candidates for this purpose, but they each have problems:

[versionInfo.json](https://github.com/Azure/iotedge/blob/main/versionInfo.json) in the Azure/iotedge repository has a single version property, so it can’t describe several independently versioned components. It is currently used by Edge Agent and Edge Hub code to log the commit ID and version number at runtime. It is also used in some of our newer release automation to verify Docker tags, automatically update `latest-iotedge-lts.json` in our Azure/azure-iotedge repository and generate our GitHub release pages.

[latest-aziot-edge.json](https://github.com/Azure/azure-iotedge/blob/main/latest-aziot-edge.json) and [latest-aziot-identity-service.json](https://github.com/Azure/azure-iotedge/blob/main/latest-aziot-identity-service.json) in the Azure/azure-iotedge repository contain version numbers specific to edgelet and the identity service, so they can’t describe Docker images.   They are used by `iotedge check` to detect the latest version of IoT Edge.

[latest-iotedge-lts.json](https://github.com/Azure/azure-iotedge/blob/main/latest-iotedge-lts.json) in the Azure/azure-iotedge repository contains the edgelet version number. It is used by `iotedge check` to detect the latest version of IoT Edge 1.1 LTS. It also lists version numbers for Edge Agent and Edge Hub images, but they are unused. Its name and contents tie it directly to 1.1 LTS.

This update introduces a new file, _product-versions.json_. The Azure/azure-iotedge repository is the right place for this file because it is the home for files related to the IoT Edge _product_ (the thing we package, ship and support), as opposed to the IoT Edge _project_, which is where our open-source code lives.

This new file is versioned and has detailed information about the products and components we ship, their versions, and their supported release channels. It can be consumed immediately by automated image publishing pipelines. Existing tools (e.g., `iotedge check` and existing automation) can migrate as needed over time.
