### PR TITLE
Move 1.5 images to branch 'release/1.5' to prep for 1.6

### DIFF
--- a/product-versions.json
+++ b/product-versions.json
@@ -156,27 +156,27 @@
             {
               "name": "azureiotedge-agent",
               "type": "dockerImage",
-              "branch": "main",
+              "branch": "release/1.5",
               "repo": "Azure/iotedge",
               "version": "1.5.40"
             },
             {
               "name": "azureiotedge-hub",
-              "branch": "main",
+              "branch": "release/1.5",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.5.40"
             },
             {
               "name": "azureiotedge-simulated-temperature-sensor",
-              "branch": "main",
+              "branch": "release/1.5",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.5.40"
             },
             {
               "name": "azureiotedge-diagnostics",
-              "branch": "main",
+              "branch": "release/1.5",
               "repo": "Azure/iotedge",
               "type": "dockerImage",
               "version": "1.5.21"


### PR DESCRIPTION
I created a new branch, `release/1.5`, in the project repo last week. This update to product-versions.json will ensure that the auto-refresh release pipelines release updates from the new branch instead of `main`. Development work for 1.6 is happening in `main`.