### PR TITLE
Remove 1.5 from stable channel

### DIFF
--- a/product-versions.json
+++ b/product-versions.json
@@ -61,64 +61,6 @@
               "version": "1.1.26"
             }
           ]
-        },
-        {
-          "name": "Azure IoT Edge",
-          "id": "aziot-edge",
-          "version": "1.5.40",
-          "componentTypes": [
-            {
-              "name": "dockerImage",
-              "platforms": [
-                {
-                  "os": "linux",
-                  "arch": [
-                    "amd64",
-                    "arm64v8",
-                    "arm32v7"
-                  ]
-                }
-              ]
-            }
-          ],
-          "components": [
-            {
-              "name": "aziot-edge",
-              "version": "1.5.21"
-            },
-            {
-              "name": "aziot-identity-service",
-              "version": "1.5.6"
-            },
-            {
-              "name": "azureiotedge-agent",
-              "type": "dockerImage",
-              "branch": "main",
-              "repo": "Azure/iotedge",
-              "version": "1.5.40"
-            },
-            {
-              "name": "azureiotedge-hub",
-              "branch": "main",
-              "repo": "Azure/iotedge",
-              "type": "dockerImage",
-              "version": "1.5.40"
-            },
-            {
-              "name": "azureiotedge-simulated-temperature-sensor",
-              "branch": "main",
-              "repo": "Azure/iotedge",
-              "type": "dockerImage",
-              "version": "1.5.40"
-            },
-            {
-              "name": "azureiotedge-diagnostics",
-              "branch": "main",
-              "repo": "Azure/iotedge",
-              "type": "dockerImage",
-              "version": "1.5.21"
-            }
-          ]
         }
       ]
     },


### PR DESCRIPTION
When IoT Edge 1.5's components were moved from branch "main" to "release/1.5", we should have also removed 1.5 from the stable channel, but it was missed. This change removes it.